### PR TITLE
Sonar only starts with this Fix

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -88,6 +88,11 @@ template "#{node['sonar']['install_dir']}/conf/sonar.properties" do
   action :create
 end
 
+#Fix permissions for Sonar installation directory. Without this, sonar does not start. 
+bash "Fix permissions for #{node['sonar']['install_dir']}" do
+  code "chown -R #{node['sonar']['username']}:#{node['sonar']['groupname']} #{node['sonar']['install_dir']}"
+end
+
 service "sonar" do
   action :start
 end


### PR DESCRIPTION
Hi,

great cookbook, thanks for your work! I just tried it out and pointed out that sonar does not start by default, because the sonar user has not enough rights on the installation directory.

This small fix makes everything work like a charm again.

Kind regards
